### PR TITLE
Jp 2334/add post synthetics

### DIFF
--- a/api_test.tf
+++ b/api_test.tf
@@ -28,7 +28,8 @@ resource "datadog_synthetics_test" "default" {
   }
   request_definition {
     url    = each.value.request_definition.url
-    method = "GET"
+    method = each.value.request_definition.method
+    body = each.value.request_definition.body
   }
   request_headers = each.value.request_headers
   status = each.value.status

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,8 @@ variable "settings" {
       type = string
       request_definition = object({
         url    = string
+        method = string
+        body   = optional(string)
       })
       request_headers = optional(object({
         Authorization = optional(string)


### PR DESCRIPTION
## Description
外型監視でmethodをGET以外も選択可能にする

## Reason
下記でPOSTの外型監視を追加したいが、こちらでGETが固定利用されていたため修正します
https://justincase.myjetbrains.com/youtrack/issue/JP-2334/%E5%A4%96%E5%9E%8B%E7%9B%A3%E8%A6%96%E8%BF%BD%E5%8A%A0

既存のdatadogリポジトリ側でmethodを指定しなくて良いよう
下記機能を利用したかったですが、alphaでの提供であり、
terraform cloudでまだバージョンが選択できなかったため本対応にしました
https://github.com/hashicorp/terraform/releases/tag/v1.3.0-alpha20220622
https://app.terraform.io/app/justincase/workspaces/datadog_joinsure-record_qa/runs/run-j8jZfqebnptM7Kvi

## 後作業
下記でmethodにGETを指定する
https://github.com/justincase-jp/datadog

## Document URL
https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test

## 確認したこと
localでterraform plan実行し、getでなくpostで外型監視が追加されることを確認しました
<details>
<summary>plan結果</summary>

```
terraform plan
Running plan in the remote backend. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

The remote workspace is configured to work with configuration at
terraform/service/joinsure-record/dev relative to the target repository.

Terraform will upload the contents of the following directory,
excluding files or directories as defined by a .terraformignore file
at /Users/kota.tomimatsu/work/jic/datadog/.terraformignore (if it is present),
in order to capture the filesystem context the remote workspace expects:
    /Users/kota.tomimatsu/work/jic/datadog

To view this run in a browser, visit:
https://app.terraform.io/app/justincase/datadog_joinsure-record_dev/runs/run-PYAqKpos5Bqk5S5B

Waiting for the plan to start...

Terraform v1.1.7
on linux_amd64
Initializing plugins and modules...
module.synthetics.datadog_synthetics_test.default["https://api-portal.dev.joinsure.jp/policy-api/actuator/health/"]: Refreshing state... [id=p5f-99s-65t]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/data-io-api/actuator/health/"]: Refreshing state... [id=tuy-kwr-b2t]
module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/policy-api/actuator/health/"]: Refreshing state... [id=abx-znz-nyt]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/claim-api/actuator/health/"]: Refreshing state... [id=6a2-bp2-pap]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/payment-api/actuator/health/"]: Refreshing state... [id=g9c-qcj-ca9]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/products-api/actuator/health/"]: Refreshing state... [id=yw8-smz-atz]
module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/claim-api/actuator/health/"]: Refreshing state... [id=vhf-nnp-n6b]
module.synthetics.datadog_synthetics_test.default["https://api-portal.dev.joinsure.jp/consumer-api/actuator/health/"]: Refreshing state... [id=uk2-wt6-5h8]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/management-api/actuator/health/"]: Refreshing state... [id=aiq-u9z-j52]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/consumer-api/actuator/health/"]: Refreshing state... [id=8xb-6b6-mnm]
module.synthetics.datadog_synthetics_test.default["https://api-portal.dev.joinsure.jp/payment-api/actuator/health/"]: Refreshing state... [id=kqc-g5y-phn]
module.synthetics.datadog_synthetics_test.default["https://api-console.dev.joinsure.jp/policy-api/actuator/health/"]: Refreshing state... [id=shq-24t-v8c]
module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/consumer-api/actuator/health/"]: Refreshing state... [id=byj-kci-yc8]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # module.synthetics.datadog_synthetics_test.default["https://api-portal.dev.joinsure.jp/payment-api/actuator/health/"] has changed
  ~ resource "datadog_synthetics_test" "default" {
      + device_ids      = []
        id              = "kqc-g5y-phn"
        name            = "API test on https://api-portal.dev.joinsure.jp/payment-api/actuator/health/"
      + request_headers = {}
      + request_query   = {}
        tags            = [
            "env:dev",
            "project:joinsure-record",
            "managed:terraform",
        ]
        # (6 unchanged attributes hidden)



        # (4 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/claim-api/claims"] will be created
  + resource "datadog_synthetics_test" "default" {
      + id         = (known after apply)
      + locations  = [
          + "aws:ap-northeast-1",
        ]
      + message    = <<-EOT
            {{^is_recovery}}外形監視にて異常を検知しました
            Datadogから各種メトリクスを確認し原因の特定をお願いします  {{/is_recovery}}
            {{#is_recovery}}外形監視が正常な値に戻りました
            必要があれば障害報告書の記入をお願いします{{/is_recovery}}
             @slack-dev_record_alert
        EOT
      + monitor_id = (known after apply)
      + name       = "API test on https://api-form.dev.joinsure.jp/claim-api/claims"
      + status     = "live"
      + tags       = [
          + "env:dev",
          + "project:joinsure-record",
          + "managed:terraform",
        ]
      + type       = "api"

      + assertion {
          + operator = "lessThan"
          + target   = "5000"
          + type     = "responseTime"
        }
      + assertion {
          + operator = "is"
          + target   = "200"
          + type     = "statusCode"
        }

      + options_list {
          + min_location_failed = 1
          + tick_every          = 1800

          + monitor_options {
              + renotify_interval = 0
            }

          + retry {
              + count    = 2
              + interval = 10000
            }
        }

      + request_definition {
          + body   = jsonencode(
                {
                  + additional_claim_properties = []
                  + claimant                    = {
                      + full_name = "保険太郎"
                      + mail      = "synthetics@justincase-tech.com"
                      + tel       = "08000000000"
                      + yomi      = "ホケンタロウ"
                    }
                  + payee_bank_account          = {
                      + account_name   = "ホケンタロウ"
                      + account_number = "1234567"
                      + account_type   = "SAVINGS"
                      + bank_code      = "009"
                      + branch_code    = "0001"
                    }
                  + posed_files                 = []
                }
            )
          + method = "POST"
          + url    = "https://api-form.dev.joinsure.jp/claim-api/claims"
        }
    }

  # module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/policy-api/policies"] will be created
  + resource "datadog_synthetics_test" "default" {
      + id         = (known after apply)
      + locations  = [
          + "aws:ap-northeast-1",
        ]
      + message    = <<-EOT
            {{^is_recovery}}外形監視にて異常を検知しました
            Datadogから各種メトリクスを確認し原因の特定をお願いします  {{/is_recovery}}
            {{#is_recovery}}外形監視が正常な値に戻りました
            必要があれば障害報告書の記入をお願いします{{/is_recovery}}
             @slack-dev_record_alert
        EOT
      + monitor_id = (known after apply)
      + name       = "API test on https://api-form.dev.joinsure.jp/policy-api/policies"
      + status     = "live"
      + tags       = [
          + "env:dev",
          + "project:joinsure-record",
          + "managed:terraform",
        ]
      + type       = "api"

      + assertion {
          + operator = "lessThan"
          + target   = "5000"
          + type     = "responseTime"
        }
      + assertion {
          + operator = "is"
          + target   = "200"
          + type     = "statusCode"
        }

      + options_list {
          + min_location_failed = 1
          + tick_every          = 1800

          + monitor_options {
              + renotify_interval = 0
            }

          + retry {
              + count    = 2
              + interval = 10000
            }
        }

      + request_definition {
          + body   = jsonencode(
                {
                  + additional_policy_properties = [
                      + {
                          + name  = "国籍"
                          + value = "日本"
                        },
                    ]
                  + agency_code                  = "666ce553"
                  + applied_at                   = "2022-01-10T09:00:00+09:00"
                  + beneficiary                  = {
                      + id           = "494290be-d6cc-4622-b46e-e3dfa766f992"
                      + name         = {
                          + full     = "山田太郎"
                          + katakana = "ヤマダタロウ"
                        }
                      + relationship = "本人"
                      + type         = "PERSON"
                    }
                  + claimant_representative      = {
                      + id           = "494290be-d6cc-4622-b46e-e3dfa766f992"
                      + name         = {
                          + full     = "山田太郎"
                          + katakana = "ヤマダタロウ"
                        }
                      + relationship = "本人"
                      + type         = "PERSON"
                    }
                  + coverages                    = [
                      + {
                          + amount        = 50000
                          + coverage_type = "一時金"
                          + name          = "入院一時金"
                        },
                    ]
                  + deductibles                  = [
                      + {
                          + amount = 5000
                          + name   = "車両補償免責金額"
                        },
                    ]
                  + insureds                     = [
                      + {
                          + declarations_answers = [
                              + {
                                  + answer   = "告知事項回答"
                                  + name     = "告知事項０１"
                                  + question = "告知事項質問内容０１"
                                },
                            ]
                          + person               = {
                              + additional_policy_properties = [
                                  + {
                                      + name  = "国籍"
                                      + value = "日本"
                                    },
                                ]
                              + date_of_birth                = "1966-06-06"
                              + name                         = {
                                  + full     = "山田太郎"
                                  + katakana = "ヤマダタロウ"
                                }
                              + sex                          = "1"
                            }
                        },
                    ]
                  + is_auto_renewal_enabled      = true
                  + order_id                     = "fM0JF7dWsdRX3g9nctiX"
                  + payment_frequency            = "MONTHLY"
                  + payment_means                = "CREDIT_CARD"
                  + plan_id                      = "27d06fbe-81e4-47eb-8672-a267e2a644b2"
                  + policyholder                 = {
                      + account_id                   = "baacea92-13fd-4c28-8612-45b8e8122b34"
                      + additional_policy_properties = [
                          + {
                              + name  = "国籍"
                              + value = "日本"
                            },
                        ]
                      + date_of_birth                = "1966-06-06"
                      + name                         = {
                          + full     = "西川テストA"
                          + katakana = "ニシカワテストA"
                        }
                      + sex                          = "1"
                    }
                  + premium_parameter            = jsonencode(
                        {
                          + 年齢 = 20
                          + 性別 = "男性"
                        }
                    )
                  + provisional_issued_at        = "2022-01-20T09:00:00+09:00"
                  + term                         = {
                      + amount = 1
                      + unit   = "年"
                    }
                }
            )
          + method = "POST"
          + url    = "https://api-form.dev.joinsure.jp/policy-api/policies"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
╷
│ Warning: Experimental feature "module_variable_optional_attrs" is active
│ 
│   on .terraform/modules/synthetics/provider.tf line 11, in terraform:
│   11:   experiments = [module_variable_optional_attrs]
│ 
│ Experimental features are subject to breaking changes in future minor or
│ patch releases, based on feedback.
│ 
│ If you have feedback on the design of this feature, please open a GitHub
│ issue to discuss it.
╵
```
</details>


