### PR TITLE
add(variables): Content-Type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -15,9 +15,15 @@ variable "settings" {
         method = string
         body   = optional(string)
       })
-      request_headers = optional(object({
-        Authorization = optional(string)
-      }))
+      request_headers = optional(
+        object({
+          Authorization = optional(string)
+          Content-Type  = optional(string)
+        })
+        # TODO: Terraform v1.3でmodifierによるデフォルト値のセットがサポートされたら使う
+        # https://discuss.hashicorp.com/t/request-for-feedback-optional-object-type-attributes-with-defaults-in-v1-3-alpha/40550
+        # }), {}
+      )
       response = object({
         time = number
         code = number


### PR DESCRIPTION
## Description

Record側のAPIテストでContent-Typeを指定する必要があるので追加
なお、Terraform Clouyd Registryにはすでにv0.0.4で追加しているのでマージ後やることは特に有りません
https://app.terraform.io/app/justincase/registry/modules/private/justincase/synthetics/datadog/0.0.4

## Reason

本当は'any()'みたいに'Content-Type'でも'Authorization'でもなんでも指定できるようにしてあげたいが解決策がないので必要時に追加する運用にさせてください🙇‍♂️

余談ですが
Terraform v1.3でmodifierによるデフォルト値のセットがサポートされるみたいで、これで解消する可能性はあるかもです
https://discuss.hashicorp.com/t/request-for-feedback-optional-object-type-attributes-with-defaults-in-v1-3-alpha/40550

また、

## Document URL

https://justincase.myjetbrains.com/youtrack/issue/JP-2334/%E5%A4%96%E5%9E%8B%E7%9B%A3%E8%A6%96%E8%BF%BD%E5%8A%A0


試しに実行したところ
```
dev $ terraform init
Initializing modules...
Downloading app.terraform.io/justincase/synthetics/datadog 0.0.4 for synthetics...　　←ここに新たなバージョンが指定されていることを確認
~略~

dev $ terraform plan

~略~
─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/claim-api/claims"] will be updated in-place
  ~ resource "datadog_synthetics_test" "default" {
        id              = "mvq-7mm-m66"
        name            = "API test on https://api-form.dev.joinsure.jp/claim-api/claims"
      ~ request_headers = {
          + "Content-Type" = "application/json"　←ここに追加されていることを確認
          - "content-type" = "application/json" -> null
        }
        tags            = [
            "env:dev",
            "project:joinsure-record",
            "managed:terraform",
        ]
        # (8 unchanged attributes hidden)



        # (4 unchanged blocks hidden)
    }

  # module.synthetics.datadog_synthetics_test.default["https://api-form.dev.joinsure.jp/policy-api/policies"] will be updated in-place
  ~ resource "datadog_synthetics_test" "default" {
        id              = "7ir-smc-w24"
        name            = "API test on https://api-form.dev.joinsure.jp/policy-api/policies"
      ~ request_headers = {
          + "Content-Type" = "application/json"　←ここに追加されていることを確認
          - "content-type" = "application/json" -> null
        }
        tags            = [
            "env:dev",
            "project:joinsure-record",
            "managed:terraform",
        ]
        # (8 unchanged attributes hidden)



        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

```