### PR TITLE
feat: `sheduling` オプションを追加

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,16 @@ variable "settings" {
         monitor_options = object({
           renotify_interval = number
         })
+        scheduling = object({
+          timeframes = list(
+            object({
+              day  = number
+              from = string
+              to   = string
+            })
+          )
+          timezone = string
+        })
       })
       status = string
     })


### PR DESCRIPTION
## Description
SSIA

## Reason
Synthetics Test の時間指定オプションを設定したいため

## Document URL
https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test#nested-schema-for-options_listscheduling
