### PR TITLE
fix: `resource` 定義に設定していなかった問題を修正

### DIFF
--- a/datadog_synthetics_test.tf
+++ b/datadog_synthetics_test.tf
@@ -25,6 +25,10 @@ resource "datadog_synthetics_test" "default" {
     monitor_options {
       renotify_interval = each.value.options_list.monitor_options.renotify_interval
     }
+    scheduling {
+      timeframes = each.value.options_list.scheduling.timeframes
+      timezone   = each.value.options_list.scheduling.timezone
+    }
   }
   request_definition {
     url    = each.value.request_definition.url


### PR DESCRIPTION
## Description
SSIA

## Reason
#6 でオプションを追加したが、 `resource` 定義に設定していないことから利用側で設定しても差分が発生しない問題が発生したため

## Document URL
N/A