### PR TITLE
fix: `timeframe` の定義を `block` になるように変更

### DIFF
--- a/datadog_synthetics_test.tf
+++ b/datadog_synthetics_test.tf
@@ -26,7 +26,7 @@ resource "datadog_synthetics_test" "default" {
       renotify_interval = each.value.options_list.monitor_options.renotify_interval
     }
     scheduling {
-      timeframes = each.value.options_list.scheduling.timeframes
+      timeframes = [for tf in each.value.options_list.scheduling.timeframes : tf]
       timezone   = each.value.options_list.scheduling.timezone
     }
   }


### PR DESCRIPTION
## Description
SSIA

## Reason
`scheduling.timeframe` がブロックとなっていないエラーが発生したため

## Document URL

<!-- 参考できるドキュメントのURL -->
