### PR TITLE
fix: `timeframes` を動的設定に変更 (その2)

### DIFF
--- a/datadog_synthetics_test.tf
+++ b/datadog_synthetics_test.tf
@@ -27,11 +27,13 @@ resource "datadog_synthetics_test" "default" {
     }
     scheduling {
       dynamic "timeframes" {
-        for_each = each.value.options_list.scheduling.timeframes
+        for_each = {
+          for tf in each.value.options_list.scheduling.timeframes : each.key => tf
+        }
 
-        day  = timeframes.day
-        from = timeframes.from
-        to   = timeframes.to
+        day  = each.value.day
+        from = each.value.from
+        to   = each.value.to
       }
       timezone = each.value.options_list.scheduling.timezone
     }


### PR DESCRIPTION
## Description
SSIA

## Reason
#11 の変更を入れてもエラーが解消しなかったため

## Document URL
N/A