### PR TITLE
fix: `timeframes` を動的設定に変更 (その5)

### DIFF
--- a/datadog_synthetics_test.tf
+++ b/datadog_synthetics_test.tf
@@ -32,9 +32,9 @@ resource "datadog_synthetics_test" "default" {
         }
 
         content {
-          day  = timeframes.day
-          from = timeframes.from
-          to   = timeframes.to
+          day  = each.value.day
+          from = each.value.from
+          to   = each.value.to
         }
       }
       timezone = each.value.options_list.scheduling.timezone


### PR DESCRIPTION
## Description
SSIA

## Reason
#14 の修正

## Document URL
N/A