### PR TITLE
fix: `timeframes` を動的設定に変更 (その7)

### DIFF
--- a/datadog_synthetics_test.tf
+++ b/datadog_synthetics_test.tf
@@ -28,13 +28,13 @@ resource "datadog_synthetics_test" "default" {
     scheduling {
       dynamic "timeframes" {
         for_each = {
-          for tf in each.value.options_list.scheduling.timeframes : each.key => tf...
+          for day in each.value.options_list.scheduling.days : each.key => day...
         }
 
         content {
-          day  = timeframes.value.day
-          from = timeframes.value.from
-          to   = timeframes.value.to
+          day  = timeframes[each.key].value
+          from = each.value.options_list.scheduling.from
+          to   = each.value.options_list.scheduling.to
         }
       }
       timezone = each.value.options_list.scheduling.timezone

--- a/variables.tf
+++ b/variables.tf
@@ -39,13 +39,9 @@ variable "settings" {
         })
         scheduling = optional(
           object({
-            timeframes = list(
-              object({
-                day  = number
-                from = string
-                to   = string
-              })
-            )
+            days     = list(number)
+            from     = string
+            to       = string
             timezone = string
           })
         )


### PR DESCRIPTION
## Description
SSIA

## Reason
#16 の続き

## Document URL
N/A